### PR TITLE
update provider init schema

### DIFF
--- a/internal/data-sources/data_source_uptrace_monitor.go
+++ b/internal/data-sources/data_source_uptrace_monitor.go
@@ -2,11 +2,13 @@ package data_sources
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	uptrace "github.com/persona-ae/terraform-provider-uptrace/internal/services"
 )
 
@@ -101,6 +103,7 @@ func (d *monitorDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	monitor, err := d.client.GetMonitorById(ctx, config.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", "Unable to read monitor: "+err.Error())
+		tflog.Error(ctx, "Uptrace Client error: "+err.Error())
 		return
 	}
 
@@ -112,6 +115,8 @@ func (d *monitorDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		Type:      types.StringValue(monitor.Type),
 		Query:     types.StringValue(monitor.Params.Query),
 	}
+	s, _ := json.MarshalIndent(state, "", "  ")
+	tflog.Debug(ctx, "state: "+string(s))
 
 	_ = resp.State.Set(ctx, &state)
 }

--- a/internal/data-sources/data_source_uptrace_monitor.go
+++ b/internal/data-sources/data_source_uptrace_monitor.go
@@ -100,13 +100,14 @@ func (d *monitorDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	monitor, err := d.client.GetMonitorById(ctx, config.ID.ValueString())
+	monitor_resp, err := d.client.GetMonitorById(ctx, config.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", "Unable to read monitor: "+err.Error())
 		tflog.Error(ctx, "Uptrace Client error: "+err.Error())
 		return
 	}
 
+	monitor := monitor_resp.Monitor
 	state := TFMonitorData{
 		ID:        types.StringValue(strconv.Itoa(monitor.ID)),
 		Name:      types.StringValue(monitor.Name),

--- a/internal/data-sources/data_source_uptrace_monitor.go
+++ b/internal/data-sources/data_source_uptrace_monitor.go
@@ -2,7 +2,6 @@ package data_sources
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -116,8 +115,6 @@ func (d *monitorDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		Type:      types.StringValue(monitor.Type),
 		Query:     types.StringValue(monitor.Params.Query),
 	}
-	s, _ := json.MarshalIndent(state, "", "  ")
-	tflog.Debug(ctx, "state: "+string(s))
-
-	_ = resp.State.Set(ctx, &state)
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }

--- a/internal/data-sources/data_source_uptrace_monitor.go
+++ b/internal/data-sources/data_source_uptrace_monitor.go
@@ -80,10 +80,17 @@ func (d *monitorDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 	}
 }
 
+type TFMonitorData struct {
+	ID        types.String `tfsdk:"id"`
+	Name      types.String `tfsdk:"name"`
+	ProjectID types.Int64  `tfsdk:"project_id"`
+	Status    types.String `tfsdk:"status"`
+	Type      types.String `tfsdk:"type"`
+	Query     types.String `tfsdk:"query"`
+}
+
 func (d *monitorDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var config struct {
-		ID types.String `tfsdk:"id"`
-	}
+	var config TFMonitorData
 
 	diags := req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
@@ -97,13 +104,14 @@ func (d *monitorDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	resp.State.Set(ctx, map[string]any{
-		"id":         strconv.Itoa(monitor.ID),
-		"name":       monitor.Name,
-		"project_id": int64(monitor.ProjectID),
-		"status":     monitor.Status,
-		"type":       monitor.Type,
-		"query":      monitor.Params.Query,
-		// TODO: validate this soon... "metrics":    monitor.Params.Metrics,
-	})
+	state := TFMonitorData{
+		ID:        types.StringValue(strconv.Itoa(monitor.ID)),
+		Name:      types.StringValue(monitor.Name),
+		ProjectID: types.Int64Value(int64(monitor.ProjectID)),
+		Status:    types.StringValue(monitor.Status),
+		Type:      types.StringValue(monitor.Type),
+		Query:     types.StringValue(monitor.Params.Query),
+	}
+
+	_ = resp.State.Set(ctx, &state)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,9 +43,14 @@ func (p *UptraceProvider) Metadata(ctx context.Context, req provider.MetadataReq
 func (p *UptraceProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"endpoint": schema.StringAttribute{
-				MarkdownDescription: "Example provider attribute",
-				Optional:            true,
+			"token": schema.StringAttribute{
+				MarkdownDescription: "API token for authentication.",
+				Required:            true,
+				Sensitive:           true,
+			},
+			"project_id": schema.StringAttribute{
+				MarkdownDescription: "Uptrace project ID.",
+				Required:            true,
 			},
 		},
 	}

--- a/internal/services/types.go
+++ b/internal/services/types.go
@@ -7,7 +7,9 @@ type GetMonitorsResponse struct {
 	Monitors []Monitor `json:"monitors"`
 }
 
-type GetMonitorByIdResponse Monitor
+type GetMonitorByIdResponse struct {
+	Monitor Monitor `json:"monitor"`
+}
 
 // start response-model vocabulary
 

--- a/internal/services/uptrace.go
+++ b/internal/services/uptrace.go
@@ -51,7 +51,6 @@ func (u *UptraceClient) do(ctx context.Context, method, endpoint string, body []
 
 	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
-		tflog.Error(ctx, "Error creating request", map[string]any{"error": err})
 		return fmt.Errorf("creating request: %w", err)
 	}
 
@@ -60,14 +59,12 @@ func (u *UptraceClient) do(ctx context.Context, method, endpoint string, body []
 
 	resp, err := u.Client.Do(req)
 	if err != nil {
-		tflog.Error(ctx, "Error performing request", map[string]any{"error": err})
 		return fmt.Errorf("performing request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		tflog.Error(ctx, "Error reading response", map[string]any{"error": err})
 		return fmt.Errorf("reading response: %w", err)
 	}
 
@@ -81,16 +78,9 @@ func (u *UptraceClient) do(ctx context.Context, method, endpoint string, body []
 	}
 
 	if out != nil {
-		tflog.Debug(ctx, "Unmarshalling into", map[string]any{
-			"type": fmt.Sprintf("%T", out),
-		})
 		if err := json.Unmarshal(respBody, out); err != nil {
-			tflog.Error(ctx, "Error decoding JSON", map[string]any{"error": err})
 			return fmt.Errorf("decoding response JSON: %w", err)
 		}
-
-		db, _ := json.Marshal(out)
-		tflog.Debug(ctx, "debug out: "+string(db))
 	}
 
 	return nil

--- a/internal/services/uptrace.go
+++ b/internal/services/uptrace.go
@@ -6,8 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const (
@@ -36,14 +37,21 @@ func (u *UptraceClient) do(ctx context.Context, method, endpoint string, body []
 	var reqBody io.Reader
 	if body != nil {
 		reqBody = bytes.NewBuffer(body)
-		log.Printf("Uptrace request: %s %s\nRequest body: %s", method, url, string(body))
+		tflog.Debug(ctx, "Uptrace request", map[string]any{
+			"method": method,
+			"url":    url,
+			"body":   string(body),
+		})
 	} else {
-		log.Printf("Uptrace request: %s %s", method, url)
+		tflog.Debug(ctx, "Uptrace request (no body)", map[string]any{
+			"method": method,
+			"url":    url,
+		})
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
-		log.Printf("Error creating request: %v", err)
+		tflog.Error(ctx, "Error creating request", map[string]any{"error": err})
 		return fmt.Errorf("creating request: %w", err)
 	}
 
@@ -52,18 +60,21 @@ func (u *UptraceClient) do(ctx context.Context, method, endpoint string, body []
 
 	resp, err := u.Client.Do(req)
 	if err != nil {
-		log.Printf("Error performing request: %v", err)
+		tflog.Error(ctx, "Error performing request", map[string]any{"error": err})
 		return fmt.Errorf("performing request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("Error reading response: %v", err)
+		tflog.Error(ctx, "Error reading response", map[string]any{"error": err})
 		return fmt.Errorf("reading response: %w", err)
 	}
 
-	log.Printf("Uptrace response: %s\nResponse body: %s", resp.Status, string(respBody))
+	tflog.Debug(ctx, "Uptrace response", map[string]any{
+		"status": resp.Status,
+		"body":   string(respBody),
+	})
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("unexpected status %s: %s", resp.Status, respBody)
@@ -71,9 +82,12 @@ func (u *UptraceClient) do(ctx context.Context, method, endpoint string, body []
 
 	if out != nil {
 		if err := json.Unmarshal(respBody, out); err != nil {
-			log.Printf("Error decoding JSON: %v", err)
+			tflog.Error(ctx, "Error decoding JSON", map[string]any{"error": err})
 			return fmt.Errorf("decoding response JSON: %w", err)
 		}
+
+		db, _ := json.Marshal(out)
+		tflog.Debug(ctx, "debug out: "+string(db))
 	}
 
 	return nil

--- a/internal/services/uptrace.go
+++ b/internal/services/uptrace.go
@@ -81,6 +81,9 @@ func (u *UptraceClient) do(ctx context.Context, method, endpoint string, body []
 	}
 
 	if out != nil {
+		tflog.Debug(ctx, "Unmarshalling into", map[string]any{
+			"type": fmt.Sprintf("%T", out),
+		})
 		if err := json.Unmarshal(respBody, out); err != nil {
 			tflog.Error(ctx, "Error decoding JSON", map[string]any{"error": err})
 			return fmt.Errorf("decoding response JSON: %w", err)


### PR DESCRIPTION
Update schema so that provider expects token and project id — fix uptrace internal type and validate.

```diff
+terraform {
+  required_providers {
+    uptrace = {
+      source = "persona-ae/uptrace"
+      version = "0.0.7"
+    }
+  }
+}
+
+provider "uptrace" {
+  project_id = "3255"
+  token = "..."
+}
+
+data "uptrace_monitor" "notify_all" {
+  id = "3592"
+}
+
+output "notify_all_name" {
+   value = data.uptrace_monitor.notify_all.name
+   description = "name test"
+}
+
+output "notify_all_query" {
+   value = data.uptrace_monitor.notify_all.query
+   description = "query test"
+}
```

```
$ terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - persona-ae/uptrace in /home/vscode/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.uptrace_monitor.notify_all: Reading...
data.uptrace_monitor.notify_all: Read complete after 1s [id=3592]

Changes to Outputs:
  + notify_all_name  = "Notify on all production errors"
  + notify_all_query = "sum($logs) | group by _group_id | group by conversation_conversation_id | group by service_name | group by service_version | where _system in (\"log:error\", \"log:fatal\") | where deployment_environment = \"production\""

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```